### PR TITLE
MORPH-4891: Remove veeam embeeded

### DIFF
--- a/lib/morpheus/cli/commands/backups_command.rb
+++ b/lib/morpheus/cli/commands/backups_command.rb
@@ -189,7 +189,7 @@ EOT
           selected_backupType_optionTypes = create_results.dig('optionTypes', params['backupType']) || []
           if !selected_backupType_optionTypes.empty?
             selected_backupType_optionTypes.each do |optiontype|
-              build_selected_backupType_optionTypes(optiontype, params, options)
+              build_selected_backupType_optionTypes(optiontype, params, options, @api_client, create_results)
             end
           end
 
@@ -534,22 +534,58 @@ EOT
     job_inputs
   end
 
-  def build_selected_backupType_optionTypes(optiontype, params, options={}, api_client=@api_client)
+  def build_selected_backupType_optionTypes(optiontype, params, options={}, api_client=@api_client, source_context={})
     #puts "Prompting for #{optiontype['fieldName']} of type #{optiontype['type']}"
     prompt_options = options[:options] || {}
+    source_params = {'optionTypeId' => optiontype['id']}
+
+    context_backup = {}
+    if source_context.is_a?(Hash)
+      if source_context['backup'].is_a?(Hash)
+        context_backup.deep_merge!(source_context['backup'])
+      end
+      # Keep root level values too since the option endpoint may use either form.
+      %w[locationType zoneId providerId].each do |field|
+        source_params[field] = source_context[field] unless source_context[field].nil?
+      end
+    end
+    context_backup.deep_merge!(params)
+
+    if context_backup['server'].is_a?(Hash)
+      context_backup['serverId'] = context_backup['server']['id'] if context_backup['serverId'].nil? && context_backup['server']['id']
+      context_backup['server'] = context_backup['server']['name'] if context_backup['server']['name']
+    end
+    if context_backup['instance'].is_a?(Hash)
+      context_backup['instanceId'] = context_backup['instance']['id'] if context_backup['instanceId'].nil? && context_backup['instance']['id']
+      context_backup['instance'] = context_backup['instance']['name'] if context_backup['instance']['name']
+    end
+    if context_backup['backupJob'].is_a?(Hash)
+      context_backup['jobId'] = context_backup['backupJob']['id'] if context_backup['jobId'].nil? && context_backup['backupJob']['id']
+      context_backup['job'] = context_backup['backupJob']['name'] if context_backup['job'].nil? && context_backup['backupJob']['name']
+    end
+
+    source_params['locationType'] = context_backup['locationType'] if source_params['locationType'].nil? && context_backup['locationType']
+    source_params['zoneId'] = context_backup['zoneId'] if source_params['zoneId'].nil? && context_backup['zoneId']
+    source_params['providerId'] = context_backup['providerId'] if source_params['providerId'].nil? && context_backup['providerId']
+
+    context_backup.each do |k, v|
+      next if v.nil?
+      source_params["backup.#{k}"] = v
+    end
+
     if ['select', 'multiSelect'].include?(optiontype['type'])
       select_options = nil
       if optiontype['selectOptions']
         if optiontype['selectOptions'].is_a?(Proc)
-          select_options = optiontype['selectOptions'].call(api_client, {})
+          select_options = optiontype['selectOptions'].call(api_client, source_params)
         else
           select_options = optiontype['selectOptions']
         end
       elsif optiontype['optionSource']
         if optiontype['optionSource'].is_a?(Proc)
-          select_options = optiontype['optionSource'].call(api_client, {})
+          select_options = optiontype['optionSource'].call(api_client, source_params)
         else
-          select_options = Morpheus::Cli::OptionTypes.load_source_options(optiontype['optionSource'], optiontype['optionSourceType'], api_client, {})
+          select_options = Morpheus::Cli::OptionTypes.load_source_options(optiontype['optionSource'], optiontype['optionSourceType'], api_client, source_params)
         end
       end
 
@@ -572,8 +608,17 @@ EOT
       end
     end
 
-    prompt_result = Morpheus::Cli::OptionTypes.prompt([optiontype], prompt_options, api_client)
-    params[optiontype['fieldName']] = prompt_result[optiontype['fieldName']] if prompt_result
+    prompt_result = Morpheus::Cli::OptionTypes.prompt([optiontype], prompt_options, api_client, source_params)
+    if prompt_result
+      field_name = optiontype['fieldName']
+      field_context = optiontype['fieldContext']
+      selected_value = nil
+      if field_context && !field_context.to_s.strip.empty?
+        selected_value = prompt_result.dig(field_context, field_name)
+      end
+      selected_value = prompt_result[field_name] if selected_value.nil?
+      params[field_name] = selected_value unless selected_value.nil?
+    end
   end
 
   def backup_list_column_definitions()

--- a/lib/morpheus/cli/commands/backups_command.rb
+++ b/lib/morpheus/cli/commands/backups_command.rb
@@ -535,7 +535,6 @@ EOT
   end
 
   def build_selected_backupType_optionTypes(optiontype, params, options={}, api_client=@api_client, source_context={})
-    #puts "Prompting for #{optiontype['fieldName']} of type #{optiontype['type']}"
     prompt_options = options[:options] || {}
     source_params = {'optionTypeId' => optiontype['id']}
 
@@ -608,7 +607,16 @@ EOT
       end
     end
 
-    prompt_result = Morpheus::Cli::OptionTypes.prompt([optiontype], prompt_options, api_client, source_params)
+    prompt_optiontype = optiontype.is_a?(Hash) ? optiontype.clone : optiontype
+    # This helper prompts one option type at a time, so dependency checks against sibling
+    # option types (dependsOnCode) can incorrectly skip valid prompts.
+    if prompt_optiontype.is_a?(Hash) && !prompt_optiontype['dependsOnCode'].to_s.empty?
+      prompt_optiontype['dependsOnCode'] = nil
+    end
+
+    puts "Prompting with optiontype: #{prompt_optiontype.to_json} and prompt options: #{prompt_options.to_json}"
+    prompt_result = Morpheus::Cli::OptionTypes.prompt([prompt_optiontype], prompt_options, api_client, source_params)
+    puts "Prompt Result: #{prompt_result.to_json}"
     if prompt_result
       field_name = optiontype['fieldName']
       field_context = optiontype['fieldContext']

--- a/lib/morpheus/cli/commands/backups_command.rb
+++ b/lib/morpheus/cli/commands/backups_command.rb
@@ -359,7 +359,7 @@ EOT
       # Prompt for backup
       if backup.nil?
         # Backup
-        available_backups = @backups_interface.list({max:10000})['backups'].collect {|it| {'name' => it['name'], 'value' => it['id']}}
+        available_backups = @backups_interface.list({max:10000, allProvider: true})['backups'].collect {|it| {'name' => it['name'], 'value' => it['id']}}
         backup_id = Morpheus::Cli::OptionTypes.prompt([{'fieldName' => 'backupId', 'fieldLabel' => 'Backup', 'type' => 'select', 'selectOptions' => available_backups, 'required' => true}], options[:options], @api_client)['backupId']
         backup = find_backup_by_name_or_id(backup_id)
         return 1 if backup.nil?
@@ -614,7 +614,6 @@ EOT
       prompt_optiontype['dependsOnCode'] = nil
     end
 
-    puts "Prompting with optiontype: #{prompt_optiontype.to_json} and prompt options: #{prompt_options.to_json}"
     prompt_result = Morpheus::Cli::OptionTypes.prompt([prompt_optiontype], prompt_options, api_client, source_params)
     puts "Prompt Result: #{prompt_result.to_json}"
     if prompt_result

--- a/lib/morpheus/cli/commands/backups_command.rb
+++ b/lib/morpheus/cli/commands/backups_command.rb
@@ -184,7 +184,15 @@ EOT
         if avail_backup_types.empty?
           raise_command_error "No available backup types found"
         else
-          params['backupType'] = Morpheus::Cli::OptionTypes.prompt([{'fieldName' => 'backupType', 'fieldLabel' => 'Backup Type', 'type' => 'select', 'selectOptions' => avail_backup_types, 'defaultValue' => avail_backup_types[0] ? avail_backup_types[0]['name'] : nil, 'required' => true}], options[:options], @api_client)['backupType']  
+          params['backupType'] = Morpheus::Cli::OptionTypes.prompt([{'fieldName' => 'backupType', 'fieldLabel' => 'Backup Type', 'type' => 'select', 'selectOptions' => avail_backup_types, 'defaultValue' => avail_backup_types[0] ? avail_backup_types[0]['name'] : nil, 'required' => true}], options[:options], @api_client)['backupType']
+          # BackupType Options Types
+          selected_backupType_optionTypes = create_results.dig('optionTypes', params['backupType']) || []
+          if !selected_backupType_optionTypes.empty?
+            selected_backupType_optionTypes.each do |optiontype|
+              build_selected_backupType_optionTypes(optiontype, params, options)
+            end
+          end
+
         end
 
         # Job / Schedule
@@ -524,6 +532,48 @@ EOT
     end
 
     job_inputs
+  end
+
+  def build_selected_backupType_optionTypes(optiontype, params, options={}, api_client=@api_client)
+    #puts "Prompting for #{optiontype['fieldName']} of type #{optiontype['type']}"
+    prompt_options = options[:options] || {}
+    if ['select', 'multiSelect'].include?(optiontype['type'])
+      select_options = nil
+      if optiontype['selectOptions']
+        if optiontype['selectOptions'].is_a?(Proc)
+          select_options = optiontype['selectOptions'].call(api_client, {})
+        else
+          select_options = optiontype['selectOptions']
+        end
+      elsif optiontype['optionSource']
+        if optiontype['optionSource'].is_a?(Proc)
+          select_options = optiontype['optionSource'].call(api_client, {})
+        else
+          select_options = Morpheus::Cli::OptionTypes.load_source_options(optiontype['optionSource'], optiontype['optionSourceType'], api_client, {})
+        end
+      end
+
+      if select_options.is_a?(Array)
+        value_field = (optiontype['config'] ? optiontype['config']['valueField'] : nil) || 'value'
+        valid_options = select_options.select do |it|
+          next false unless it.is_a?(Hash)
+          next false if it['isGroup'] == true
+          !it[value_field].to_s.strip.empty?
+        end
+        if valid_options.empty?
+          no_options_message = select_options.find {|it| it.is_a?(Hash) && !it['name'].to_s.strip.empty? }
+          no_options_message = no_options_message ? no_options_message['name'] : nil
+          if optiontype['required']
+            raise_command_error(no_options_message || "No available options found for #{optiontype['fieldLabel'] || optiontype['fieldName']}")
+          else
+            return nil
+          end
+        end
+      end
+    end
+
+    prompt_result = Morpheus::Cli::OptionTypes.prompt([optiontype], prompt_options, api_client)
+    params[optiontype['fieldName']] = prompt_result[optiontype['fieldName']] if prompt_result
   end
 
   def backup_list_column_definitions()

--- a/lib/morpheus/cli/commands/backups_command.rb
+++ b/lib/morpheus/cli/commands/backups_command.rb
@@ -615,7 +615,6 @@ EOT
     end
 
     prompt_result = Morpheus::Cli::OptionTypes.prompt([prompt_optiontype], prompt_options, api_client, source_params)
-    puts "Prompt Result: #{prompt_result.to_json}"
     if prompt_result
       field_name = optiontype['fieldName']
       field_context = optiontype['fieldContext']


### PR DESCRIPTION
# Summary

Fix CLI implementation to work with Plugin backup Providers

# Root Cause
- returned providerslist not getting the plugin backup providers
- not prompting for optiontypes based on provider 

# Fix

- Add backupTypes from plugin provided backupTypes (in morpehus-ui) and edit CLI calls  

# Testing

- created backups with veeam and commvault via the CLI
- validated in UI and Logs
