### PR TITLE
MORPH-17279 Resolve vSphere clusters for affinity lists

### DIFF
--- a/lib/morpheus/cli/commands/affinity_groups_command.rb
+++ b/lib/morpheus/cli/commands/affinity_groups_command.rb
@@ -15,6 +15,7 @@ class Morpheus::Cli::AffinityGroupsCommand
     @affinity_groups_interface = @api_client.affinity_groups
     @clouds_interface = @api_client.clouds
     @clusters_interface = @api_client.clusters
+    @cloud_resource_pools_interface = @api_client.cloud_resource_pools
   end
 
   def handle(args)
@@ -26,21 +27,45 @@ class Morpheus::Cli::AffinityGroupsCommand
     params = {}
     optparse = Morpheus::Cli::OptionParser.new do |opts|
       opts.banner = subcommand_usage()
-      opts.on('--cloud CLOUD', String, "Filter by cloud name or id") do |val|
+      opts.on('--cloud CLOUD', String, "Cloud name or id. Combine with --cluster to scope to a vSphere cluster (resource pool) owned by this cloud.") do |val|
         options[:cloud] = val
       end
-      opts.on('--cluster CLUSTER', String, "Filter by cluster name or id") do |val|
+      opts.on('--cluster CLUSTER', String, "Cluster name or id. A unique name can select a managed or vSphere cluster; combine with --cloud to disambiguate a vSphere cluster.") do |val|
         options[:cluster] = val
       end
       build_standard_list_options(opts, options)
       opts.footer = "List affinity groups.\n" \
-        "Requires a scope: use --cloud or --cluster. There is no unscoped list endpoint."
+        "Requires a scope: use --cloud, --cluster, or --cloud CLOUD --cluster CLUSTER. There is no unscoped list endpoint."
     end
     optparse.parse!(args)
     verify_args!(args:args, optparse:optparse, count:0)
     connect(options)
 
-    if options[:cloud]
+    if options[:cloud] && options[:cluster]
+      cloud = find_cloud_by_name_or_id(options[:cloud])
+      return 1 if cloud.nil?
+      pool = find_resource_pool_cluster_by_name_or_id(cloud, options[:cluster])
+      return 1 if pool.nil?
+      params.merge!(parse_list_options(options))
+      params['poolId'] = pool['id']
+      @clouds_interface.setopts(options)
+      if options[:dry_run]
+        print_dry_run @clouds_interface.dry.list_affinity_groups(cloud['id'], params)
+        return
+      end
+      json_response = @clouds_interface.list_affinity_groups(cloud['id'], params)
+      render_response(json_response, options, 'affinityGroups') do
+        affinity_groups = json_response['affinityGroups']
+        print_h1 "Affinity Groups: #{cloud['name']} / #{pool['name']}", parse_list_subtitles(options), options
+        if affinity_groups.empty?
+          print cyan, "No affinity groups found.", reset, "\n"
+        else
+          print as_pretty_table(affinity_groups, affinity_group_list_columns, options)
+          print_results_pagination(json_response)
+        end
+        print reset, "\n"
+      end
+    elsif options[:cloud]
       cloud = find_cloud_by_name_or_id(options[:cloud])
       return 1 if cloud.nil?
       params.merge!(parse_list_options(options))
@@ -62,18 +87,33 @@ class Morpheus::Cli::AffinityGroupsCommand
         print reset, "\n"
       end
     elsif options[:cluster]
-      cluster = find_cluster_by_name_or_id(options[:cluster])
-      return 1 if cluster.nil?
+      cluster_scope = find_cluster_list_scope_by_name_or_id(options[:cluster])
+      return 1 if cluster_scope.nil?
       params.merge!(parse_list_options(options))
-      @clusters_interface.setopts(options)
-      if options[:dry_run]
-        print_dry_run @clusters_interface.dry.list_affinity_groups(cluster['id'], params)
-        return
+      if cluster_scope[:type] == :managed_cluster
+        cluster = cluster_scope[:cluster]
+        @clusters_interface.setopts(options)
+        if options[:dry_run]
+          print_dry_run @clusters_interface.dry.list_affinity_groups(cluster['id'], params)
+          return
+        end
+        json_response = @clusters_interface.list_affinity_groups(cluster['id'], params)
+        scope_name = cluster['name']
+      else
+        cloud = cluster_scope[:cloud]
+        pool = cluster_scope[:pool]
+        params['poolId'] = pool['id']
+        @clouds_interface.setopts(options)
+        if options[:dry_run]
+          print_dry_run @clouds_interface.dry.list_affinity_groups(cloud['id'], params)
+          return
+        end
+        json_response = @clouds_interface.list_affinity_groups(cloud['id'], params)
+        scope_name = "#{cloud['name']} / #{pool['name']}"
       end
-      json_response = @clusters_interface.list_affinity_groups(cluster['id'], params)
       render_response(json_response, options, 'affinityGroups') do
         affinity_groups = json_response['affinityGroups']
-        print_h1 "Affinity Groups: #{cluster['name']}", parse_list_subtitles(options), options
+        print_h1 "Affinity Groups: #{scope_name}", parse_list_subtitles(options), options
         if affinity_groups.empty?
           print cyan, "No affinity groups found.", reset, "\n"
         else

--- a/lib/morpheus/cli/mixins/infrastructure_helper.rb
+++ b/lib/morpheus/cli/mixins/infrastructure_helper.rb
@@ -21,6 +21,11 @@ module Morpheus::Cli::InfrastructureHelper
     @clouds_interface
   end
 
+  def clusters_interface
+    raise "#{self.class} has not defined @clusters_interface" if @clusters_interface.nil?
+    @clusters_interface
+  end
+
   def networks_interface
     # @api_client.networks
     raise "#{self.class} has not defined @networks_interface" if @networks_interface.nil?
@@ -412,6 +417,138 @@ module Morpheus::Cli::InfrastructureHelper
     else
       return resource_pools[0]
     end
+  end
+
+  # Resolve a cloud-owned vSphere cluster: a ComputeZonePool with type='Cluster'
+  # that belongs to the given cloud. This is distinct from a Morpheus managed
+  # cluster (ComputeServerGroup, resolved via ClustersInterface / /api/clusters).
+  #
+  # MORPH-17279: --cloud CLOUD --cluster CLUSTER must resolve CLUSTER within
+  # CLOUD's own resource pools, not the top-level managed-cluster namespace.
+  # `cloud` is the already-resolved cloud Hash (from find_cloud_by_name_or_id).
+  def find_resource_pool_cluster_by_name_or_id(cloud, val)
+    if val.to_s =~ /\A\d{1,}\Z/
+      return find_resource_pool_cluster_by_id(cloud, val)
+    else
+      return find_resource_pool_cluster_by_name(cloud, val)
+    end
+  end
+
+  def find_resource_pool_cluster_by_id(cloud, id)
+    begin
+      # Scoped to the cloud so the server itself verifies pool ownership --
+      # ZoneResourcePoolsController#show 404s when the pool's zone does not
+      # match the requested cloud.
+      json_response = resource_pools_interface.get(cloud['id'], id.to_i)
+    rescue RestClient::Exception => e
+      if e.response && e.response.code == 404
+        print_red_alert "Cluster not found by id #{id} in cloud '#{cloud['name']}'"
+        return nil
+      else
+        raise e
+      end
+    end
+    resource_pool = json_response['resourcePool']
+    if resource_pool.nil?
+      print_red_alert "Cluster not found by id #{id} in cloud '#{cloud['name']}'"
+      return nil
+    end
+    if resource_pool['type'].to_s != 'Cluster'
+      print_red_alert "Resource pool #{id} in cloud '#{cloud['name']}' is a '#{resource_pool['type'] || 'unknown'}' resource pool, not a Cluster"
+      return nil
+    end
+    return resource_pool
+  end
+
+  def find_resource_pool_cluster_by_name(cloud, name)
+    json_response = resource_pools_interface.list(cloud['id'], {name: name.to_s, type: 'Cluster'})
+    # The cloud-scoped resource-pools endpoint returns a pool *tree*, backfilling
+    # ancestor folder pools so the hierarchy renders correctly. Ancestors do not
+    # satisfy our name/type filter, so re-filter here rather than trusting the
+    # raw result size for ambiguity detection.
+    resource_pools = (json_response['resourcePools'] || []).select do |it|
+      it['type'].to_s == 'Cluster' && (it['name'].to_s == name.to_s || it['displayName'].to_s == name.to_s)
+    end
+    if resource_pools.empty?
+      print_red_alert "Cluster not found by name '#{name}' in cloud '#{cloud['name']}'.\n" \
+        "To look up a Morpheus managed cluster instead, use --cluster '#{name}' without --cloud."
+      return nil
+    elsif resource_pools.size > 1
+      print_red_alert "#{resource_pools.size} clusters found by name '#{name}' in cloud '#{cloud['name']}'. Use a numeric cluster id instead."
+      rows = resource_pools.collect do |it|
+        {id: it['id'], name: it['name']}
+      end
+      puts as_pretty_table(rows, [:id, :name], {color:red})
+      return nil
+    else
+      return resource_pools[0]
+    end
+  end
+
+  def find_managed_cluster_by_name_or_id(val, report_not_found=true)
+    cluster = nil
+    if val.to_s =~ /\A\d{1,}\Z/
+      begin
+        cluster = clusters_interface.get(val.to_i)['cluster']
+      rescue RestClient::Exception => e
+        raise e unless e.response && e.response.code == 404
+      end
+    else
+      clusters = clusters_interface.list({name: val})['clusters'] || []
+      if clusters.size > 1
+        print_red_alert "#{clusters.size} managed clusters found by name '#{val}'. Use a numeric cluster id instead."
+        rows = clusters.collect {|it| {id: it['id'], name: it['name']} }
+        puts as_pretty_table(rows, [:id, :name], {color:red})
+        return nil
+      end
+      cluster = clusters[0]
+    end
+    if cluster.nil? && report_not_found
+      print_red_alert "Managed cluster not found by name or id '#{val}'.\n" \
+        "If '#{val}' is a vSphere cluster owned by a cloud, use --cloud CLOUD --cluster #{val} instead."
+    end
+    cluster
+  end
+
+  def find_cluster_list_scope_by_name_or_id(val)
+    if val.to_s =~ /\A\d{1,}\Z/
+      cluster = find_managed_cluster_by_name_or_id(val)
+      return cluster ? {type: :managed_cluster, cluster: cluster} : nil
+    end
+
+    managed_clusters = clusters_interface.list({name: val})['clusters'] || []
+    if managed_clusters.size > 1
+      print_red_alert "#{managed_clusters.size} managed clusters found by name '#{val}'. Use a numeric cluster id instead."
+      rows = managed_clusters.collect {|it| {id: it['id'], name: it['name']} }
+      puts as_pretty_table(rows, [:id, :name], {color:red})
+      return nil
+    elsif managed_clusters.size == 1
+      return {type: :managed_cluster, cluster: managed_clusters[0]}
+    end
+
+    json_response = resource_pools_interface.list_without_cloud({name: val.to_s, type: 'Cluster', max: 1000})
+    resource_pools = (json_response['resourcePools'] || []).select do |it|
+      it['type'].to_s == 'Cluster' && (it['name'].to_s == val.to_s || it['displayName'].to_s == val.to_s)
+    end
+    if resource_pools.empty?
+      print_red_alert "No managed or vSphere cluster found by name '#{val}'."
+      return nil
+    elsif resource_pools.size > 1
+      print_red_alert "#{resource_pools.size} vSphere clusters found by name '#{val}'. Use --cloud CLOUD --cluster #{val} to disambiguate."
+      rows = resource_pools.collect do |it|
+        {id: it['id'], name: it['name'], cloud: it['zone'] && it['zone']['name']}
+      end
+      puts as_pretty_table(rows, [:id, :name, :cloud], {color:red})
+      return nil
+    end
+
+    resource_pool = resource_pools[0]
+    cloud = resource_pool['zone']
+    if cloud.nil? || cloud['id'].nil?
+      print_red_alert "vSphere cluster '#{val}' does not include its owning cloud."
+      return nil
+    end
+    {type: :cloud_pool, cloud: cloud, pool: resource_pool}
   end
 
   def find_resource_pool_group_by_name_or_id(val)

--- a/test/cli/affinity_groups_cluster_scope_test.rb
+++ b/test/cli/affinity_groups_cluster_scope_test.rb
@@ -1,0 +1,171 @@
+require 'test/unit'
+require 'stringio'
+require 'morpheus'
+
+class AffinityGroupsClusterScopeTest < Test::Unit::TestCase
+  class FakeCloudsInterface
+    attr_reader :calls
+
+    def initialize(cloud)
+      @cloud = cloud
+      @calls = []
+      @dry = false
+    end
+
+    def setopts(_options)
+      self
+    end
+
+    def dry
+      @dry = true
+      self
+    end
+
+    def get(id, params = {})
+      @calls << [:get, id, params]
+      {'zone' => @cloud}
+    end
+
+    def list(params = {})
+      @calls << [:list, params]
+      {'zones' => [@cloud]}
+    end
+
+    def list_affinity_groups(id, params = {})
+      @calls << [:list_affinity_groups, id, params]
+      return {'affinityGroups' => []} unless @dry
+
+      {method: :get, url: "/api/zones/#{id}/affinity-groups", params: params}
+    end
+  end
+
+  class FakeResourcePoolsInterface
+    attr_reader :calls
+
+    def initialize(pool)
+      @pool = pool
+      @calls = []
+    end
+
+    def get(cloud_id, id, params = {})
+      @calls << [:get, cloud_id, id, params]
+      {'resourcePool' => @pool}
+    end
+
+    def list(cloud_id, params = {})
+      @calls << [:list, cloud_id, params]
+      {'resourcePools' => [@pool]}
+    end
+
+    def list_without_cloud(params = {})
+      @calls << [:list_without_cloud, params]
+      {'resourcePools' => [@pool]}
+    end
+  end
+
+  class FakeClustersInterface
+    attr_reader :calls
+
+    def initialize(clusters = [])
+      @clusters = clusters
+      @calls = []
+      @dry = false
+    end
+
+    def setopts(_options)
+      self
+    end
+
+    def dry
+      @dry = true
+      self
+    end
+
+    def list(params = {})
+      @calls << [:list, params]
+      {'clusters' => @clusters.select {|cluster| cluster['name'] == params[:name]}}
+    end
+
+    def list_affinity_groups(id, params = {})
+      @calls << [:list_affinity_groups, id, params]
+      return {'affinityGroups' => []} unless @dry
+
+      {method: :get, url: "/api/clusters/#{id}/affinity-groups", params: params}
+    end
+  end
+
+  def setup
+    @cloud = {'id' => 59, 'name' => 'vCenter Cloud'}
+    @pool = {
+      'id' => 501,
+      'name' => 'QA',
+      'type' => 'Cluster',
+      'zone' => @cloud
+    }
+  end
+
+  def test_cloud_qualified_cluster_sends_pool_id
+    command, pools, = build_command
+
+    output = capture_stdout do
+      command.list(['--cloud', 'vCenter Cloud', '--cluster', 'QA', '--dry-run'])
+    end
+
+    assert_match(%r{/api/zones/59/affinity-groups}, output)
+    assert_match(/poolId=501/, output)
+    assert_equal [[:list, 59, {name: 'QA', type: 'Cluster'}]], pools.calls
+  end
+
+  def test_cluster_name_falls_back_to_unique_vsphere_cluster
+    command, pools, clusters = build_command
+
+    output = capture_stdout { command.list(['--cluster', 'QA', '--dry-run']) }
+
+    assert_match(%r{/api/zones/59/affinity-groups}, output)
+    assert_match(/poolId=501/, output)
+    assert_equal [[:list, {name: 'QA'}]], clusters.calls
+    assert_equal [
+      [:list_without_cloud, {name: 'QA', type: 'Cluster', max: 1000}]
+    ], pools.calls
+  end
+
+  def test_managed_cluster_takes_precedence
+    managed_cluster = {'id' => 8, 'name' => 'QA'}
+    command, pools, clusters = build_command([managed_cluster])
+
+    output = capture_stdout { command.list(['--cluster', 'QA', '--dry-run']) }
+
+    assert_match(%r{/api/clusters/8/affinity-groups}, output)
+    assert_equal [
+      [:list, {name: 'QA'}],
+      [:list_affinity_groups, 8, {}]
+    ], clusters.calls
+    assert_empty pools.calls
+  end
+
+  private
+
+  def build_command(managed_clusters = [])
+    clouds = FakeCloudsInterface.new(@cloud)
+    pools = FakeResourcePoolsInterface.new(@pool)
+    clusters = FakeClustersInterface.new(managed_clusters)
+    command = Morpheus::Cli::AffinityGroupsCommand.new
+    command.define_singleton_method(:connect) do |_options|
+      @clouds_interface = clouds
+      @clusters_interface = clusters
+      @cloud_resource_pools_interface = pools
+    end
+    [command, pools, clusters]
+  end
+
+  def capture_stdout
+    terminal = Morpheus::Terminal.instance
+    original = terminal.stdout
+    buffer = StringIO.new
+    terminal.set_stdout(buffer)
+    yield
+    buffer.string
+  ensure
+    terminal.set_stdout(original)
+  end
+end


### PR DESCRIPTION
Fixes MORPH-17279 by allowing  affinity-groups list --cluster <name>  to resolve a uniquely named vSphere cluster when no Morpheus managed cluster matches.

Managed clusters retain precedence for backward compatibility. Users can also specify  --cloud <cloud> --cluster <cluster>  to explicitly select a vSphere cluster within a cloud.

Testing

• Added offline coverage for vSphere cluster resolution and managed-cluster precedence.
• Live-validated against the  QA  vSphere cluster. The command returned all 21 scoped affinity groups with correct pagination.